### PR TITLE
Fix typo cinder->Cinder

### DIFF
--- a/cfp.txt
+++ b/cfp.txt
@@ -45,7 +45,7 @@ Problem
  - How can we build common tooling to achieve
     - Better automation and management in IT and DevOps
     - Broad vendor support and effient control plane operations for virtualization and container orchestration
- - Openstack has achieved this for itself with cinder but it's hard to use outside of Openstack
+ - Openstack has achieved this for itself with Cinder but it's hard to use outside of Openstack
 
 Solution
  - Abstraction!

--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@ params:
                 </section>
 
                 <section>
-                    <h2>But what about cinder</h2>
+                    <h2>But what about Cinder</h2>
                         <ul style="list-style: none">
                             <li>&#10004;Mature and stable</li>
                             <li>&#10004;Broad vendor support</li>
@@ -122,7 +122,7 @@ params:
                     <table>
                         <tr>
                             <td class="operand"></td>
-                            <td class="operand">cinder</td>
+                            <td class="operand">Cinder</td>
                         </tr>
                         <tr>
                             <td class="operand">-</td>


### PR DESCRIPTION
Cinder is a given name of a software component, and therefore should
be capitalized.